### PR TITLE
Make "-more-", "-unset-", "-error-" stylistically consistent

### DIFF
--- a/npyscreen/wgfilenamecombo.py
+++ b/npyscreen/wgfilenamecombo.py
@@ -18,7 +18,7 @@ class FilenameCombo(wgcombobox.ComboBox):
         
     def _print(self):
         if self.value == None:
-            printme = '- Unset -'
+            printme = '-unset-'
         else:
             try:
                 printme = self.display_value(self.value)

--- a/npyscreen/wgmultiline.py
+++ b/npyscreen/wgmultiline.py
@@ -10,7 +10,7 @@ import weakref
 import collections
 import copy
 
-MORE_LABEL = "- more -" # string to tell user there are more options
+MORE_LABEL = "-more-" # string to tell user there are more options
 
 class FilterPopupHelper(Popup.Popup):
     def create(self):


### PR DESCRIPTION
Previously, widgets used `- more -`, `-unset-`, `- Unset -` and `-error-`.
This pull request makes them consistent: `-more-`, `-unset-`, `-error-`.