### PR TITLE
Fix incorrect minimum heigh check in multiline

### DIFF
--- a/npyscreen/wgmultiline.py
+++ b/npyscreen/wgmultiline.py
@@ -44,7 +44,6 @@ class MultiLine(widget.Widget):
     """Display a list of items to the user.  By overloading the display_value method, this widget can be made to 
 display different kinds of objects.  Given the standard definition, 
 the same effect can be achieved by altering the __str__() method of displayed objects"""
-    _MINIMUM_HEIGHT = 2 # Raise an error if not given this.
     _contained_widgets = textbox.Textfield
     _contained_widget_height = 1
     def __init__(self, screen, values = None, value = None,
@@ -63,7 +62,9 @@ the same effect can be achieved by altering the __str__() method of displayed ob
         self.allow_filtering = allow_filtering
         self.widgets_inherit_color = widgets_inherit_color
         super(MultiLine, self).__init__(screen, **keywords)
-        if self.height < self.__class__._MINIMUM_HEIGHT:
+        
+        # Requires space for at least two widgets, one for content and another for "more"
+        if self.height < self._contained_widget_height * 2:
             raise widget.NotEnoughSpaceForWidget("Height of %s allocated. Not enough space allowed for %s" % (self.height, str(self)))
         self.make_contained_widgets()
 


### PR DESCRIPTION
The minimum height check by default assumes a 
contained widget height of 1 line. Because it requires space for
at least two containing widgets this is set to 2.
Setting this internal should not be required by inheriting classes.
Instead the check should use the _contained_widget_height property.

Currently having contained widgets with a height > 1 and two or more values with
less than two times the space available will cause an infinite recursion loop.