### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 
 setup(
 	name="npyscreen",


### PR DESCRIPTION
Our build tool attempts to pass all python packages the `egg_info` command, which allows controlling where the egg_info gets generated in order to do an out-of-source build. This fails on some older distutils setups, eg:

```
Starting >>> python-npyscreen
--- stderr: python-npyscreen
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'egg_info'
---
Failed   <<< python-npyscreen [0.37s, exited with code 1]
```

This should be a safe, drop in replacement.

Some context: https://stackoverflow.com/questions/25337706/setuptools-vs-distutils-why-is-distutils-still-a-thing