### PR TITLE
Changed serialization for OptionSingleChoice

### DIFF
--- a/npyscreen/apOptions.py
+++ b/npyscreen/apOptions.py
@@ -60,7 +60,7 @@ class OptionList(object):
     def define_serialize_functions(self):
         self.SERIALIZE_FUNCTIONS = {
             OptionFreeText:         self.save_text,
-            OptionSingleChoice:     self.save_text,
+            OptionSingleChoice:     self.save_multi_text,
             OptionMultiChoice:      self.save_multi_text,
             OptionMultiFreeText:    self.save_text,
             OptionBoolean:          self.save_bool,
@@ -71,7 +71,7 @@ class OptionList(object):
     
         self.UNSERIALIZE_FUNCTIONS = {
             OptionFreeText:         self.reload_text,
-            OptionSingleChoice:     self.reload_text,
+            OptionSingleChoice:     self.load_multi_text,
             OptionMultiChoice:      self.load_multi_text,
             OptionMultiFreeText:    self.reload_text,
             OptionBoolean:          self.load_bool,


### PR DESCRIPTION
Changed serialization for OptionSingleChoice as saved as list not single value.

When OptionList tries to save options to file SingleChoice option saves not single value but a list.
It cannot be serialized then and catches `AttributeError: 'OptionSingleChoice' object has no attribute 'decode'`

This issue can be solved or by changing serialization type (as i.e. MultiChoice) or add decode attribute to `OptionSingleChoice`. IMO first option is more convenient as both `SingleChoice` and `MultiChoice` inherits from `_OptionLimitedChoices_`